### PR TITLE
Add weight similarity (sigma) analysis script

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Only three third-party packages are used: `numpy`, `torch`, `safetensors`
 
 ```bash
 # 1) Clone the repo
-git clone https://github.com/yang3121099/Shadow-FT
+git clone https://github.com/wutaiqiang/Shadow-FT
 cd Shadow-FT
 
 # 2) Install only what this script needs

--- a/README.md
+++ b/README.md
@@ -102,6 +102,62 @@ Use this bash file to start training!
 Please refer to <a href="https://github.com/open-compass/opencompass" target="_blank">OpenCompass</a> for evaluation.
 
 
+### Weight Similarity (σ)
+
+`src/shadow/weight_similarity.py` reproduces the relative gap ratio σ from Section 2.3 of the paper:
+
+$$\sigma(W_A, W_B) = \frac{\sum |W_A - W_B|}{\sum |W_A| + \sum |W_B|}$$
+
+Lower σ means the two checkpoints share more of their weight mass — which is the empirical
+foundation of Shadow-FT (a paired Base/Instruct share ≳98% of weight mass, so a delta
+trained on Base transfers cleanly to Instruct).
+
+The script iterates **one transformer layer at a time** by parsing
+`model.safetensors.index.json`, so it works for 70B+ checkpoints without loading the
+whole state dict.
+
+**Usage:**
+
+```bash
+python3 src/shadow/weight_similarity.py \
+    --B <path_to_base_model> \
+    --I <path_to_instruct_model>
+```
+
+Only three third-party packages are used: `numpy`, `torch`, `safetensors`
+(all already pulled in by the standard LLaMA-Factory install above).
+
+**Reference σ values (from our runs):**
+
+| Base (--B)                   | Instruct (--I)                   | σ      |
+|------------------------------|----------------------------------|--------|
+| `Qwen3-4B-Base`              | `Qwen3-4B-Instruct-2507`         | 0.0562 |
+| `Qwen3-4B-Base`              | `Qwen3-4B-Base-Ins`              | 0.0558 |
+| `Qwen3-4B-Base-Ins`          | `Qwen3-4B-Instruct-2507`         | 0.0057 |
+
+**Minimal end-to-end verification (from a clean machine):**
+
+```bash
+# 1) Clone the repo
+git clone https://github.com/yang3121099/Shadow-FT
+cd Shadow-FT
+
+# 2) Install only what this script needs
+pip install numpy torch safetensors "huggingface_hub[cli]"
+
+# 3) Download a paired Base / Instruct checkpoint (~8 GB each)
+huggingface-cli download Qwen/Qwen3-4B-Base         --local-dir ./Qwen3-4B-Base
+huggingface-cli download Qwen/Qwen3-4B-Instruct-2507 --local-dir ./Qwen3-4B-Instruct-2507
+
+# 4) Run the σ analysis — expected final line: "Average sigma ... ~ 0.0562"
+python3 src/shadow/weight_similarity.py \
+    --B ./Qwen3-4B-Base \
+    --I ./Qwen3-4B-Instruct-2507
+```
+
+If the printed average σ matches the reference value (±1e-3), the script is working correctly.
+
+
 ### Future Plan
 
 - [ ] Introduce evaluation scripts in this repo.

--- a/src/shadow/weight_similarity.py
+++ b/src/shadow/weight_similarity.py
@@ -1,0 +1,164 @@
+"""
+Weight Similarity (sigma) between a Base model and an Instruct model.
+
+Reproduces the relative gap ratio σ from Shadow-FT (arXiv: 2505.12716, Sec 2.3):
+
+    σ(W_A, W_B) = sum(|W_A - W_B|) / (sum(|W_A|) + sum(|W_B|))
+
+Implementation notes:
+  * Iterates over transformer layers one at a time by parsing
+    ``model.safetensors.index.json`` in the Base model directory.
+  * Only loads the keys belonging to the current layer, keeping memory low
+    even for 70B+ checkpoints.
+  * BF16 tensors are up-cast to FP32 before the subtraction.
+
+Usage:
+    python3 src/shadow/weight_similarity.py --B <base_model_dir> --I <instruct_model_dir>
+"""
+
+import os
+import json
+import re
+import argparse
+
+import numpy as np
+import torch
+from safetensors import safe_open
+
+
+# -------------------------------
+# Helper: parse the safetensors index to discover layers and their keys
+# -------------------------------
+
+def parse_safetensors_index(json_path):
+    with open(json_path, "r") as f:
+        index_data = json.load(f)
+
+    weight_map = index_data["weight_map"]
+    layer_pattern = re.compile(r"model\.layers\.(\d+)\.")
+    layers = set()
+    layer_to_keys = {}
+
+    for key in weight_map.keys():
+        match = layer_pattern.search(key)
+        if match:
+            layer_idx = int(match.group(1))
+            layers.add(layer_idx)
+            if layer_idx not in layer_to_keys:
+                layer_to_keys[layer_idx] = []
+            layer_to_keys[layer_idx].append(key)
+
+    total_layers = max(layers) + 1 if layers else 0
+    return {
+        "total_layers": total_layers,
+        "layer_to_keys": layer_to_keys,
+    }
+
+
+# -------------------------------
+# Helper: load only the requested keys from *.safetensors shards
+# -------------------------------
+
+def load_selected_weights_optimized(folder_path, selected_keys, device="cpu"):
+    weights = {}
+    files = [f for f in os.listdir(folder_path) if f.endswith(".safetensors")]
+    requested_keys = set(selected_keys)
+    found_keys = set()
+
+    for filename in files:
+        full_path = os.path.join(folder_path, filename)
+        try:
+            with safe_open(full_path, framework="pt", device=device) as f:
+                file_keys = set(f.keys())
+                intersect = requested_keys & file_keys
+                for key in intersect:
+                    tensor = f.get_tensor(key)
+                    if tensor.dtype == torch.bfloat16:
+                        tensor = tensor.float()
+                    weights[key] = tensor.cpu().numpy()
+                    found_keys.add(key)
+        except Exception as e:
+            print(f"[Error] Failed to read {full_path}: {e}")
+
+    not_found = requested_keys - found_keys
+    if not_found:
+        for key in sorted(not_found):
+            print(f"    [missing] {key}")
+
+    return weights
+
+
+# -------------------------------
+# Metrics
+# -------------------------------
+
+def calculate_sigma(w_A, w_B):
+    diff = np.abs(w_A - w_B).sum()
+    total = np.abs(w_A).sum() + np.abs(w_B).sum()
+    return diff / total
+
+
+def calculate_sparsity_ratio(w_A, w_B, threshold=1e-5):
+    return np.mean(np.abs(w_A - w_B) < threshold)
+
+
+# -------------------------------
+# Main
+# -------------------------------
+
+def main(base_model, instruct_model):
+    folder_A = base_model
+    folder_B = instruct_model
+    index_json_name = "model.safetensors.index.json"
+
+    json_path_A = os.path.join(folder_A, index_json_name)
+    json_info = parse_safetensors_index(json_path_A)
+    num_layers = json_info["total_layers"]
+    layer_to_keys = json_info["layer_to_keys"]
+
+    all_sigmas = []  # per-key sigma values across all layers
+
+    print(f"Total layers: {num_layers}")
+
+    for layer_idx in range(num_layers):
+        print(f"Processing Layer {layer_idx} ...")
+
+        keys_in_layer = layer_to_keys.get(layer_idx, [])
+        if not keys_in_layer:
+            continue
+
+        A_weights = load_selected_weights_optimized(folder_A, keys_in_layer.copy(), device="cpu")
+        B_weights = load_selected_weights_optimized(folder_B, keys_in_layer.copy(), device="cpu")
+
+        sigmas = []
+        for key in keys_in_layer:
+            if key in A_weights and key in B_weights:
+                sigma = calculate_sigma(A_weights[key], B_weights[key])
+                sigmas.append(sigma)
+                print(f"key: {key}, sigma: {sigma}")
+
+        all_sigmas.extend(sigmas)
+
+        del A_weights, B_weights
+        torch.cuda.empty_cache()
+
+    print("Average sigma across all tensors:\n", np.mean(all_sigmas))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Compare two LLaMA-style models' weights using the sigma metric "
+                    "(Shadow-FT, arXiv: 2505.12716, Sec 2.3)."
+    )
+    parser.add_argument("--B", type=str, required=True,
+                        help="Path to base model directory (e.g., Llama-3.1-8B/).")
+    parser.add_argument("--I", type=str, required=True,
+                        help="Path to instruct model directory (e.g., Llama-3.1-8B-Instruct/).")
+
+    args = parser.parse_args()
+
+    main(args.B, args.I)
+
+    # Example invocations:
+    # python3 src/shadow/weight_similarity.py --B Qwen3-8B-Base/ --I Qwen3-8B/
+    # python3 src/shadow/weight_similarity.py --B Llama-3.1-8B/ --I Llama-3.1-8B-Instruct/


### PR DESCRIPTION
## Summary

Add the weight similarity σ analysis tool (Shadow-FT paper Sec 2.3) and corresponding README documentation.

### Changes

- **`src/shadow/weight_similarity.py`** (new): Computes the per-layer relative gap ratio σ = Σ|W_A−W_B| / (Σ|W_A|+Σ|W_B|) between a Base and Instruct model. Uses layer-by-layer safetensors loading via `model.safetensors.index.json` for memory efficiency (works for 70B+ models).
- **`README.md`**: Add a "Weight Similarity (σ)" section under Quick Start with:
  - Formula definition
  - CLI usage (`--B` / `--I`)
  - Reference σ values from Qwen3-4B family runs
  - End-to-end verification recipe (clone → install → download → run)

### Reference σ values

| Base (--B) | Instruct (--I) | σ |
|---|---|---|
| Qwen3-4B-Base | Qwen3-4B-Instruct-2507 | 0.0562 |
| Qwen3-4B-Base | Qwen3-4B-Base-Ins | 0.0558 |
| Qwen3-4B-Base-Ins | Qwen3-4B-Instruct-2507 | 0.0057 |

## Test plan

- [ ] Run `python3 src/shadow/weight_similarity.py --B ./Qwen3-4B-Base --I ./Qwen3-4B-Instruct-2507` — expect average σ ≈ 0.0562 (±1e-3)
- [ ] Verify README renders correctly on GitHub (formula, table, code blocks)
